### PR TITLE
[1.19.2] Fix shield blocking not firing related advancement triggers

### DIFF
--- a/src/main/java/org/infernalstudios/shieldexp/events/ShieldExpansionEvents.java
+++ b/src/main/java/org/infernalstudios/shieldexp/events/ShieldExpansionEvents.java
@@ -168,6 +168,8 @@ public class ShieldExpansionEvents {
             double damageFactor = (1.00 - getShieldValue(item, "blastResistance"));
             double usedDurability = event.getAmount() * damageFactor;
             player.level.playSound(null, player.getOnPos(), SoundEvents.SHIELD_BLOCK, SoundSource.HOSTILE, 1.0f, 1.0f);
+
+            float damageTaken = 0.0F;
             if (LivingEntityAccess.get(player).getParryWindow() > 0) {
                 player.level.playSound(null, player.getOnPos(), SoundsInit.PARRY_SOUND.get(), SoundSource.HOSTILE, 1.0f, 1.0f);
                 damageItem(player, (int) usedDurability);
@@ -186,11 +188,6 @@ public class ShieldExpansionEvents {
                     else if (event.getAmount() > 0) stamina(player, item, (int) (2 * damageFactor));
                 }
                 event.setCanceled(true);
-
-                // if on server, trigger the entity hurt player
-                if (!player.level.isClientSide) {
-                    CriteriaTriggers.ENTITY_HURT_PLAYER.trigger((ServerPlayer) player, event.getSource(), event.getAmount(), 0.0F, true);
-                }
             } else {
                 damageItem(player, (int) usedDurability);
                 if (!Config.cooldownDisabled()) {
@@ -209,15 +206,16 @@ public class ShieldExpansionEvents {
                     } else if (event.getAmount() > 0) stamina(player, item, 3);
                 }
                 event.setCanceled(true);
-                if (Config.advancedExplosionsEnabled()) {
-                    float damageTaken = (float) (event.getAmount() / 2 * damageFactor);
-                    player.hurt(new DamageSource("partialblast"), damageTaken);
 
-                    // if on server, trigger the entity hurt player
-                    if (!player.level.isClientSide) {
-                        CriteriaTriggers.ENTITY_HURT_PLAYER.trigger((ServerPlayer) player, event.getSource(), event.getAmount(), damageTaken, true);
-                    }
+                if (Config.advancedExplosionsEnabled()) {
+                    damageTaken = (float) (event.getAmount() / 2 * damageFactor);
+                    player.hurt(new DamageSource("partialblast"), damageTaken);
                 }
+            }
+
+            // if on server, trigger the entity hurt player
+            if (!player.level.isClientSide) {
+                CriteriaTriggers.ENTITY_HURT_PLAYER.trigger((ServerPlayer) player, event.getSource(), event.getAmount(), damageTaken, true);
             }
         }
     }


### PR DESCRIPTION
Fixes #35 for Minecraft 1.19.2.

The root of the issue comes from the cancellation of the events used by the shield handler. Because the advancement trigger is fired after the event check (i.e. if the event is not cancelled), the current behavior leads to vanilla not knowing what the hell is going on. To counter act this, all event listeners that cancel the attack event now manually fire the trigger themselves.

The only caveat to this is that damage absorbed by the shield (for projectiles only) is not recorded in player statistics, but that wasn't happening anyway since we were cancelling the event if the player blocked with one of Shield Expansion's own shields.

I am happy to write my own backports, but cherry-picking the commit I made and applying it to other maintained branches of the mod should be enough to apply the fix onto other versions of the game for this project. Cheers.