### PR TITLE
[1.19.2] Fixup shield synchronization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,3 +196,10 @@ def parseConfig(File config) {
         return (new ConfigSlurper().parse(prop))
     }
 }
+
+idea {
+    module {
+        downloadJavadoc = true
+        downloadSources = true
+    }
+}

--- a/src/main/java/org/infernalstudios/shieldexp/events/ClientEvents.java
+++ b/src/main/java/org/infernalstudios/shieldexp/events/ClientEvents.java
@@ -65,7 +65,7 @@ public class ClientEvents {
 
     // this event is run on Minecraft.clearLevel() when leaving singleplayer OR disconnecting from a server
     @SubscribeEvent
-    public static void onLoggingOut(ClientPlayerNetworkEvent.LoggingOut event) {
+    public void onLoggingOut(ClientPlayerNetworkEvent.LoggingOut event) {
         ShieldDataLoader.clearAll();
     }
 

--- a/src/main/java/org/infernalstudios/shieldexp/events/ClientEvents.java
+++ b/src/main/java/org/infernalstudios/shieldexp/events/ClientEvents.java
@@ -21,6 +21,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ShieldItem;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -29,6 +30,7 @@ import net.minecraftforge.registries.RegistryObject;
 import org.infernalstudios.shieldexp.ShieldExpansion;
 import org.infernalstudios.shieldexp.access.LivingEntityAccess;
 import org.infernalstudios.shieldexp.init.ItemsInit;
+import org.infernalstudios.shieldexp.init.ShieldDataLoader;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -59,6 +61,12 @@ public class ClientEvents {
         Player player = Minecraft.getInstance().player;
         if (player != null && Minecraft.getInstance().options.keyAttack.isDown() && LivingEntityAccess.get(player).getBlocking())
             player.stopUsingItem();
+    }
+
+    // this event is run on Minecraft.clearLevel() when leaving singleplayer OR disconnecting from a server
+    @SubscribeEvent
+    public static void onLoggingOut(ClientPlayerNetworkEvent.LoggingOut event) {
+        ShieldDataLoader.clearAll();
     }
 
     private static void copyOptionalResourcePackIfMissing() {

--- a/src/main/java/org/infernalstudios/shieldexp/events/ShieldExpansionEvents.java
+++ b/src/main/java/org/infernalstudios/shieldexp/events/ShieldExpansionEvents.java
@@ -28,6 +28,7 @@ import net.minecraftforge.registries.ForgeRegistries;
 import org.infernalstudios.shieldexp.init.Config;
 import org.infernalstudios.shieldexp.ShieldExpansion;
 import org.infernalstudios.shieldexp.access.LivingEntityAccess;
+import org.infernalstudios.shieldexp.init.ShieldDataLoader;
 import org.infernalstudios.shieldexp.init.SoundsInit;
 
 import static org.infernalstudios.shieldexp.init.ShieldDataLoader.SHIELD_STATS;
@@ -239,7 +240,7 @@ public class ShieldExpansionEvents {
     //reads a shield attribute from the given shield's stats map, or the default map if no map is found
     public static Double getShieldValue(Item item, String value) {
         String key = ForgeRegistries.ITEMS.getKey(item).toString();
-        return SHIELD_STATS.containsKey(key) ? SHIELD_STATS.get(key).get(value) : SHIELD_STATS.get("shieldexp:default").get(value);
+        return SHIELD_STATS.containsKey(key) ? SHIELD_STATS.get(key).get(value) : SHIELD_STATS.get(ShieldDataLoader.DEFAULT_SHIELD_NAME).get(value);
     }
 
     //increases the current used stamina count of the given player, and removes the blocking state if the given shield's stamina is used up

--- a/src/main/java/org/infernalstudios/shieldexp/init/Config.java
+++ b/src/main/java/org/infernalstudios/shieldexp/init/Config.java
@@ -1,5 +1,6 @@
 package org.infernalstudios.shieldexp.init;
 
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -65,10 +66,11 @@ public class Config  {
     }
 
     //automatically adds shields to the shield list and config file on datapack load
-    public static void extendList(String id) {
+    public static void extendList(ResourceLocation id) {
+        String itemID = id.toString();
         List<String> newList = new java.util.ArrayList<>(List.of());
         newList.addAll(SHIELD_LIST.get());
-        if (!newList.contains(id)) newList.add(id);
+        if (!newList.contains(itemID)) newList.add(itemID);
         SHIELD_LIST.set(newList);
     }
 

--- a/src/main/java/org/infernalstudios/shieldexp/init/NetworkInit.java
+++ b/src/main/java/org/infernalstudios/shieldexp/init/NetworkInit.java
@@ -19,6 +19,8 @@ public class NetworkInit {
         INSTANCE = NetworkRegistry.newSimpleChannel(new ResourceLocation(ShieldExpansion.MOD_ID, "packets"), () -> "1.0", s -> true, s -> true);
 
         INSTANCE.registerMessage(nextID(), SyncShields.class, SyncShields::encode, SyncShields::new, SyncShields::handle);
+
+        // TODO Delete - This is only kept here so the network isn't angry
         INSTANCE.registerMessage(nextID(), ClearShields.class, ClearShields::encode, ClearShields::new, ClearShields::handle);
     }
 }

--- a/src/main/java/org/infernalstudios/shieldexp/init/ShieldDataLoader.java
+++ b/src/main/java/org/infernalstudios/shieldexp/init/ShieldDataLoader.java
@@ -61,8 +61,6 @@ public class ShieldDataLoader extends SimpleJsonResourceReloadListener {
         Player player = event.getEntity();
 
         if (!player.level.isClientSide()){
-            NetworkInit.INSTANCE.send(PacketDistributor.PLAYER.with(() -> (ServerPlayer) player), new ClearShields());
-
             for (Map.Entry<ResourceLocation, JsonElement> file : toSync){
                 NetworkInit.INSTANCE.send(PacketDistributor.PLAYER.with(() -> (ServerPlayer) player), new SyncShields(file.getKey(), file.getValue()));
             }

--- a/src/main/java/org/infernalstudios/shieldexp/init/ShieldDataLoader.java
+++ b/src/main/java/org/infernalstudios/shieldexp/init/ShieldDataLoader.java
@@ -63,6 +63,8 @@ public class ShieldDataLoader extends SimpleJsonResourceReloadListener {
         Player player = event.getEntity();
 
         if (!player.level.isClientSide()){
+            NetworkInit.INSTANCE.send(PacketDistributor.PLAYER.with(() -> (ServerPlayer) player), new ClearShields());
+
             for (Map.Entry<ResourceLocation, JsonElement> file : toSync){
                 NetworkInit.INSTANCE.send(PacketDistributor.PLAYER.with(() -> (ServerPlayer) player), new SyncShields(file.getKey(), file.getValue()));
             }

--- a/src/main/java/org/infernalstudios/shieldexp/init/ShieldDataLoader.java
+++ b/src/main/java/org/infernalstudios/shieldexp/init/ShieldDataLoader.java
@@ -29,10 +29,10 @@ import java.util.Map;
 public class ShieldDataLoader extends SimpleJsonResourceReloadListener {
     public static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().disableHtmlEscaping().create();
     public static Map<ResourceLocation, JsonElement> FILE_MAP = new HashMap<>();
-    public static final Map<String, Map<String, Double>> SHIELD_STATS = new ShieldStatsMap();
+    public static final Map<ResourceLocation, Map<String, Double>> SHIELD_STATS = new ShieldStatsMap();
     public static final List<Map.Entry<ResourceLocation, JsonElement>> toSync = new ArrayList<>();
 
-    public static final String DEFAULT_SHIELD_NAME = ShieldExpansion.MOD_ID + ":default";
+    public static final ResourceLocation DEFAULT_SHIELD_NAME = new ResourceLocation(ShieldExpansion.MOD_ID, "default");
 
     public ShieldDataLoader() {
         super(GSON, "shields");
@@ -49,7 +49,7 @@ public class ShieldDataLoader extends SimpleJsonResourceReloadListener {
         FILE_MAP = files;
 
         for (ResourceLocation name : FILE_MAP.keySet()) {
-            if (ForgeRegistries.ITEMS.containsKey(name) || name.toString().equals(DEFAULT_SHIELD_NAME)) {
+            if (ForgeRegistries.ITEMS.containsKey(name) || name.equals(DEFAULT_SHIELD_NAME)) {
                 JsonElement data = files.get(name);
 
                 parse(name, data.getAsJsonObject());
@@ -72,8 +72,7 @@ public class ShieldDataLoader extends SimpleJsonResourceReloadListener {
     }
 
     public static void parse(ResourceLocation name, JsonObject data) {
-        String key = name.toString();
-        if (ForgeRegistries.ITEMS.containsKey(name) || key.equals(DEFAULT_SHIELD_NAME)) {
+        if (ForgeRegistries.ITEMS.containsKey(name) || name.equals(DEFAULT_SHIELD_NAME)) {
             Map<String, Double> stats = new HashMap<>();
             stats.put("cooldownTicks", data.getAsJsonObject().get("cooldownTicks").getAsDouble());
             stats.put("speedFactor", data.getAsJsonObject().get("speedFactor").getAsDouble());
@@ -82,11 +81,11 @@ public class ShieldDataLoader extends SimpleJsonResourceReloadListener {
             stats.put("stamina", data.getAsJsonObject().get("stamina").getAsDouble());
             stats.put("blastResistance", data.getAsJsonObject().get("blastResistance").getAsDouble());
             stats.put("flatDamage", data.getAsJsonObject().get("flatDamage").getAsDouble());
-            SHIELD_STATS.remove(key);
-            SHIELD_STATS.put(key, stats);
+            SHIELD_STATS.remove(name);
+            SHIELD_STATS.put(name, stats);
 
-            if (!key.equals(DEFAULT_SHIELD_NAME))
-                Config.extendList(key);
+            if (!name.equals(DEFAULT_SHIELD_NAME))
+                Config.extendList(name);
         }
     }
 
@@ -94,7 +93,7 @@ public class ShieldDataLoader extends SimpleJsonResourceReloadListener {
         SHIELD_STATS.clear();
     }
 
-    private static class ShieldStatsMap extends HashMap<String, Map<String, Double>> {
+    private static class ShieldStatsMap extends HashMap<ResourceLocation, Map<String, Double>> {
         // This should NEVER need to be used, but just in case the data is missing, this is the hard-coded default data
         private static final Map<String, Double> EMERGENCY_DEFAULT = new HashMap<>() {
             {

--- a/src/main/java/org/infernalstudios/shieldexp/init/ShieldDataLoader.java
+++ b/src/main/java/org/infernalstudios/shieldexp/init/ShieldDataLoader.java
@@ -111,7 +111,7 @@ public class ShieldDataLoader extends SimpleJsonResourceReloadListener {
             // in case this map ever gets used, log a fatal error
             @Override
             public Double get(Object key) {
-                ShieldExpansion.LOGGER.fatal("The client is missing shield data from the server! This includes the default shield data! Please report this bug to Infernal Studios.");
+                ShieldExpansion.LOGGER.warn("The client is missing shield data from the server! This includes the default shield data! Please report this bug to Infernal Studios.");
 
                 return super.get(key);
             }

--- a/src/main/java/org/infernalstudios/shieldexp/network/ClearShields.java
+++ b/src/main/java/org/infernalstudios/shieldexp/network/ClearShields.java
@@ -1,15 +1,11 @@
 package org.infernalstudios.shieldexp.network;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.world.entity.player.Player;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.network.NetworkEvent;
-import org.infernalstudios.shieldexp.init.ShieldDataLoader;
 
 import java.util.function.Supplier;
 
+// TODO Delete - This is only kept here so the network isn't angry
 public class ClearShields {
     public ClearShields(FriendlyByteBuf buf) {
     }
@@ -21,15 +17,6 @@ public class ClearShields {
     }
 
     public void handle(Supplier<NetworkEvent.Context> ctx){
-        ctx.get().enqueueWork(this::handle);
         ctx.get().setPacketHandled(true);
-    }
-
-    @OnlyIn(Dist.CLIENT)
-    private void handle() {
-        Player player = Minecraft.getInstance().player;
-        if (player != null){
-            ShieldDataLoader.clearAll();
-        }
     }
 }

--- a/src/main/java/org/infernalstudios/shieldexp/network/SyncShields.java
+++ b/src/main/java/org/infernalstudios/shieldexp/network/SyncShields.java
@@ -1,11 +1,9 @@
 package org.infernalstudios.shieldexp.network;
 
 import com.google.gson.JsonElement;
-import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
-import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.network.NetworkEvent;
@@ -40,9 +38,8 @@ public class SyncShields {
 
     @OnlyIn(Dist.CLIENT)
     private void handle() {
-        Player player = Minecraft.getInstance().player;
-        if (player != null){
-            ShieldDataLoader.parse(shield, data.getAsJsonObject());
-        }
+        // trust that the client can handle this even if the player isn't ready
+        // this data isn't stored to the local player so even if the player is null, it's fine
+        ShieldDataLoader.parse(shield, data.getAsJsonObject());
     }
 }


### PR DESCRIPTION
This PR fixes up how shields are synchronized in Shield Expansion. This was done by doing the following:

- Removing the usage of the `ClearShields` packet.
  - It still exists in the mod so that clients and servers with different versions after this PR is merged will continue to work.
- Making the client clear shields when the player logs out of a world.
- Removing the local player null check in the `SyncShields` packet.
- Including an ultimate, final, fallback shield map in case the default never got synced to the client.
  - If this ever happens, a fatal log message will be sent to the console.

Additionally, a small closure was added to the buildscript to assist with IntelliJ IDEA refusing to download linked source and javadoc files.

- Fixes #47.
- Supersedes #40.
- Supersedes #48.