### PR TITLE
Fix un-enchantable shields Modest Magic incompatibility.

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/item/enchantable/durability.json
+++ b/common/src/main/resources/data/minecraft/tags/item/enchantable/durability.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#shieldexp:shields"
+  ]
+}


### PR DESCRIPTION
This fixes an issue with shields being un-enchantable with Modest Magic by adding it to the `minecraft:enchantable/durability` tag, as that is the tag that MM uses to determine what is compatible with their tablets.

It's literally just adding `#shieldexp:shields` to the durability tag.